### PR TITLE
유저 탈퇴 구현

### DIFF
--- a/src/accounts/accounts.module.ts
+++ b/src/accounts/accounts.module.ts
@@ -13,15 +13,19 @@ import { AccountsController } from './accounts.controller';
 import { AccountsService } from './accounts.service';
 import { BalanceService } from 'src/balances/balances.service';
 import { UserGoalService } from 'src/usergoal/userGoal.service';
+import { UserModule } from 'src/user/user.module';
+import { GoalModule } from 'src/goal/goal.module';
 
 @Module({
   imports: [
     HttpModule,
     TypeOrmModule.forFeature([Users, Accounts, UserGoals, Balances]),
     forwardRef(() => AuthModule),
+    forwardRef(() => UserModule),
+    GoalModule,
   ],
   controllers: [AccountsController],
-  providers: [AccountsService, UserService, AuthService,
-    JwtService, BalanceService, UserGoalService],
+  providers: [AccountsService, BalanceService],
+  exports: [AccountsService, BalanceService]
 })
 export class AccountsModule {}

--- a/src/user/dto/exitUser.dto.ts
+++ b/src/user/dto/exitUser.dto.ts
@@ -19,7 +19,7 @@ export class ExitUserDTO {
 
   @IsString()
   @IsNotEmpty()
-  readonly loginCateGory: string;
+  readonly loginCategory: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/user/dto/exitUser.dto.ts
+++ b/src/user/dto/exitUser.dto.ts
@@ -1,0 +1,35 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class ExitUserDTO {
+  @IsString()
+  @IsNotEmpty()
+  readonly email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly nickname: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly image: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly loginCateGory: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly pinCode: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly refreshToken: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly description: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -288,58 +288,57 @@ export class UserController {
     @Req() req,
     @Param('userId') userId: number,
     @Res() res: Response){
-      if(req.user !== userId){
-        throw new HttpException(
-          '권한이 없는 호출입니다.', 
-          HttpStatus.BAD_REQUEST
-          );
-      }
-      const data: ExitUserDTO = {
-        email: "Exit User", // 현재 협의가 필요
-        name: "탈퇴한 사용자",
-        nickname: "탈퇴한 사용자",
-        image: null,
-        loginCateGory: null,
-        pinCode: null,
-        refreshToken: null,
-        description: null
-      }
-      // 1. 회원 정보 빈 값 처리
-      await this.userService.exitUser(userId, data);
-      const getGoal = await this.userGoalService.getGoalByUserId(userId);
-      for(let i = 0; i < getGoal.length; i++) {
-        let goalId: number = getGoal[i].goalId.goalId;
-        let accessUserGoalData: AccessUserGoalDTO = {
-          userId, goalId };
-        // 2. 개인 목표 삭제
-        if(getGoal[i].goalId.headCount === 1) {
-          await this.userGoalService.exitGoal(accessUserGoalData);
-          await this.goalService.deleteGoal(goalId);
+        if(req.user !== Number(userId)){
+          throw new HttpException(
+            '권한이 없는 호출입니다.', 
+            HttpStatus.BAD_REQUEST
+            );
         }
-        // 3. 팀 목표 처리
-        // 3.1 현재 모집중인 팀 목표에 대한 탈퇴 처리
-        if(getGoal[i].goalId.status === "recruit"){
-          const find = await this.userGoalService.findUser(accessUserGoalData);
-          if (find == null) {
-            // error - 참가하지 않은 유저입니다.
-            throw new HttpException('참가하지 않았습니다.', HttpStatus.BAD_REQUEST);
-          } else {
-            // 중간 테이블 삭제
+        const data: ExitUserDTO = {
+          email: "Exit User", // 현재 협의가 필요
+          name: "탈퇴한 사용자",
+          nickname: "탈퇴한 사용자",
+          image: null,
+          loginCategory: null,
+          pinCode: null,
+          refreshToken: null,
+          description: null
+        }
+        // 1. 회원 정보 빈 값 처리
+        await this.userService.exitUser(userId, data);
+        const getGoal = await this.userGoalService.getGoalByUserId(userId);
+        for(let i = 0; i < getGoal.length; i++) {
+          let goalId: number = getGoal[i].goalId.goalId;
+          let accessUserGoalData: AccessUserGoalDTO = {
+            userId, goalId };
+          // 2. 개인 목표 삭제
+          if(getGoal[i].goalId.headCount === 1) {
             await this.userGoalService.exitGoal(accessUserGoalData);
-            // 참가자 숫자 변동
-            getGoal[i].goalId.headCount -= 1;
-            await this.goalService.updateGoalCurCount(goalId, getGoal[i].goalId.headCount);
+            await this.goalService.deleteGoal(goalId);
           }
-        }else {
-          // 3.2 현재 진행중이거나 완료된 목표에 대해서 balanceId = 0 처리
-          const balanceId: number = getGoal[i].balanceId.balanceId;
-          const current: number = 0;
-          await this.balanceService.updateBalance(balanceId, current);
+          // 3. 팀 목표 처리
+          // 3.1 현재 모집중인 팀 목표에 대한 탈퇴 처리
+          if(getGoal[i].goalId.status === "recruit"){
+            const find = await this.userGoalService.findUser(accessUserGoalData);
+            if (find == null) {
+              // error - 참가하지 않은 유저입니다.
+              throw new HttpException('참가하지 않았습니다.', HttpStatus.BAD_REQUEST);
+            } else {
+              // 중간 테이블 삭제
+              await this.userGoalService.exitGoal(accessUserGoalData);
+              // 참가자 숫자 변동
+              getGoal[i].goalId.headCount -= 1;
+              await this.goalService.updateGoalCurCount(goalId, getGoal[i].goalId.headCount);
+            }
+          }else {
+            // 3.2 현재 진행중이거나 완료된 목표에 대해서 balanceId = 0 처리
+            const balanceId: number = getGoal[i].balanceId.balanceId;
+            const current: number = 0;
+            await this.balanceService.updateBalance(balanceId, current);
+          }
+          // account 정보를 변경하는 method 필요
         }
-        // account 정보를 변경하는 method 필요
-
-      }
-      res.json({ message: "회원 탈퇴가 완료되었습니다." });
+        res.json({ message: "회원 탈퇴가 완료되었습니다." });
   }
 
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -15,15 +15,19 @@ import { GoalService } from 'src/goal/goal.service';
 import { BadgeService } from 'src/badges/badge.service';
 import { Badges } from 'src/models/badges';
 import { UserBadges } from 'src/models/userbadges';
+import { GoalModule } from 'src/goal/goal.module';
+import { AccountsModule } from 'src/accounts/accounts.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Users, UserGoals, Goals,
     Accounts, Balances, Badges, UserBadges]),
     forwardRef(() => AuthModule),
+    GoalModule,
+    AccountsModule,
   ],
-  providers: [UserService, GoalService, UserGoalService, BadgeService],
+  providers: [UserService, BadgeService],
   controllers: [UserController],
-  exports: [UserService],
+  exports: [UserService, BadgeService],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Users } from '../models/users';
+import { ExitUserDTO } from './dto/exitUser.dto';
 import { ModifyUserInfoDTO } from './dto/modifyUser.dto';
 
 @Injectable()
@@ -64,5 +65,9 @@ export class UserService {
     targetUserInfo.image = image;
     targetUserInfo.description = description;
     await this.userRepository.save(targetUserInfo);
+  }
+
+  async exitUser(userId: number, data: ExitUserDTO) {
+    await this.userRepository.update({userId}, data);
   }
 }


### PR DESCRIPTION
유저 정보
email ( unique ) : Exit User
	해결책 2: unique: false
	회원 가입시 이메일과 이름을 둘 다 비교하는 로직 추가
	Exit User 로 바뀜

name : 탈퇴한 사용자
nickname : 탈퇴한 사용자
image : null
loginCateGory: null
pinCode: null
refreshToken: null
description: null

해당 유저가 참가한 목표

진행중인 개인 목표는 삭제
delete goal(userId)
진행중인 팀 목표에서는 탈퇴한 사용자라고 나오게 할 것
balance : 0

문제점 : 완료된 목표일 경우 accountId와 balanceId를 삭제 할 것